### PR TITLE
Log discrete metrics such as activation frequency

### DIFF
--- a/sparsify/losses.py
+++ b/sparsify/losses.py
@@ -101,7 +101,7 @@ class LossConfigs(BaseModel):
 
 def calc_loss(
     orig_acts: dict[str, Tensor],
-    sae_acts: dict[str, dict[str, Tensor]],
+    sae_acts: dict[str, dict[str, Float[Tensor, "... dim"]]],
     orig_logits: Float[Tensor, "batch pos vocab"],
     new_logits: Float[Tensor, "batch pos vocab"],
     loss_configs: LossConfigs,
@@ -153,13 +153,5 @@ def calc_loss(
                     c=sae_act["c"],
                 )
                 loss = loss + loss_config.coeff * loss_dict[f"loss/{config_type}/{name}"]
-
-        # Record L_0 norm of the cs
-        l_0_norm = torch.norm(sae_act["c"], p=0, dim=-1).mean()
-        loss_dict[f"sparsity/L_0/{name}"] = l_0_norm
-
-        # Record fraction of zeros in the cs
-        frac_zeros = (sae_act["c"] == 0).sum() / sae_act["c"].numel()
-        loss_dict[f"sparsity/frac_zeros/{name}"] = frac_zeros
 
     return loss, loss_dict

--- a/sparsify/metrics.py
+++ b/sparsify/metrics.py
@@ -1,0 +1,130 @@
+import torch
+import wandb
+from jaxtyping import Float
+from torch import Tensor
+from transformer_lens.utils import lm_cross_entropy_loss
+
+
+class DiscreteMetrics:
+    """Manages metrics such as dict activation frequencies and alive dictionary elements."""
+
+    def __init__(self, dict_sizes: dict[str, int], has_pos_dim: bool, device: torch.device) -> None:
+        """Initialize the DiscreteMetrics object.
+
+        Args:
+            dict_sizes: Sizes of the dictionaries for each sae position.
+            has_pos_dim: Whether the sae activations have a position dimension.
+            device: Device to store the dictionary element frequencies on.
+        """
+        self.has_pos_dim = has_pos_dim
+        self.tokens_used = 0  # Number of tokens used in dict_el_frequencies
+        self.dict_el_frequencies: dict[str, Float[Tensor, "dims"]] = {  # noqa: F821
+            sae_pos: torch.zeros(dict_size, device=device)
+            for sae_pos, dict_size in dict_sizes.items()
+        }
+
+    def update_dict_el_frequencies(
+        self, sae_acts: dict[str, dict[str, Float[Tensor, "... dim"]]], batch_tokens: int
+    ) -> None:
+        """Update the dictionary element frequencies with the new batch frequencies.
+
+        Args:
+            sae_acts: Dictionary of activations for each SAE position.
+            batch_tokens: Number of tokens used to produce the sae acts.
+        """
+        sum_dims = (0, 1) if self.has_pos_dim else (0,)
+        for sae_pos in self.dict_el_frequencies:
+            self.dict_el_frequencies[sae_pos] += (sae_acts[sae_pos]["c"] != 0).sum(dim=sum_dims)
+        self.tokens_used += batch_tokens
+
+    def collect_for_logging(self, log_wandb_histogram: bool = True) -> dict[str, list[float] | int]:
+        """Collect the discrete metrics for logging.
+
+        Currently collects:
+        - The number of alive dictionary elements for each hook.
+        - The histogram of dictionary element activation frequencies for each hook (if
+          log_wandb_histogram is True).
+
+        Note that the dictionary element frequencies are divided by the number of tokens used to
+        calculate them.
+
+        Args:
+            log_wandb_histogram: Whether to log the dictionary element activation frequency
+                histograms to wandb.
+        """
+        log_dict = {}
+        for sae_pos in self.dict_el_frequencies:
+            self.dict_el_frequencies[sae_pos] /= self.tokens_used
+
+            log_dict[f"sparsity/alive_dict_elements/{sae_pos}"] = (
+                self.dict_el_frequencies[sae_pos].gt(0).sum().item()
+            )
+
+            if log_wandb_histogram:
+                data = [[s] for s in self.dict_el_frequencies[sae_pos]]
+                table = wandb.Table(data=data, columns=["dict element activation frequency"])
+                plot = wandb.plot.histogram(
+                    table,
+                    "dict element activation frequency",
+                    title=f"{sae_pos} (most_recent_n_tokens={self.tokens_used} "
+                    f"dict_size={self.dict_el_frequencies[sae_pos].shape[0]})",
+                )
+                log_dict[f"sparsity/dict_el_frequencies_hist/{sae_pos}"] = plot
+
+        return log_dict
+
+
+def collect_wandb_metrics(
+    loss: float,
+    grad_updates: int,
+    sae_acts: dict[str, dict[str, Float[Tensor, "... dim"]]],
+    loss_dict: dict[str, Float[Tensor, ""]],
+    grad_norm: float | None,
+    orig_logits: Float[Tensor, "... dim"],
+    new_logits: Float[Tensor, "... dim"],
+    tokens: Float[Tensor, "... dim"],
+) -> dict[str, int | float]:
+    """Collect metrics for logging to wandb.
+
+    Args:
+        loss: The final loss value.
+        grad_updates: The number of gradient updates performed.
+        sae_acts: Dictionary of activations for each SAE position.
+        loss_dict: Dictionary of loss values that make up the final loss.
+        grad_norm: The norm of the gradients.
+        orig_logits: The logits produced by the original model.
+        new_logits: The logits produced by the SAE model.
+        tokens: The tokens used to produce the logits and activations.
+
+    Returns:
+        Dictionary of metrics to log to wandb.
+    """
+    wandb_log_info = {"loss": loss, "grad_updates": grad_updates}
+    for name, sae_act in sae_acts.items():
+        # Record L_0 norm of the cs
+        l_0_norm = torch.norm(sae_act["c"], p=0, dim=-1).mean().item()
+        wandb_log_info[f"sparsity/L_0/{name}"] = l_0_norm
+
+        # Record fraction of zeros in the cs
+        frac_zeros = ((sae_act["c"] == 0).sum() / sae_act["c"].numel()).item()
+        wandb_log_info[f"sparsity/frac_zeros/{name}"] = frac_zeros
+
+    for loss_name, loss_value in loss_dict.items():
+        wandb_log_info[loss_name] = loss_value.item()
+
+    if grad_norm is not None:
+        wandb_log_info["grad_norm"] = grad_norm
+
+    orig_model_performance_loss = lm_cross_entropy_loss(orig_logits, tokens, per_token=False)
+    sae_model_performance_loss = lm_cross_entropy_loss(new_logits, tokens, per_token=False)
+
+    wandb_log_info.update(
+        {
+            "performance/orig_model_ce_loss": orig_model_performance_loss.item(),
+            "performance/sae_model_ce_loss": sae_model_performance_loss.item(),
+            "performance/difference_loss": (
+                orig_model_performance_loss - sae_model_performance_loss
+            ).item(),
+        },
+    )
+    return wandb_log_info

--- a/sparsify/scripts/train_tlens_saes/run_train_tlens_saes.py
+++ b/sparsify/scripts/train_tlens_saes/run_train_tlens_saes.py
@@ -19,6 +19,7 @@ from jaxtyping import Float, Int
 from pydantic import (
     BaseModel,
     ConfigDict,
+    Field,
     NonNegativeFloat,
     NonNegativeInt,
     PositiveFloat,
@@ -32,16 +33,20 @@ from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 from transformer_lens import HookedTransformer, HookedTransformerConfig
 from transformer_lens.hook_points import HookPoint
-from transformer_lens.utils import lm_cross_entropy_loss
 
 from sparsify.data import DataConfig, create_data_loader
 from sparsify.log import logger
 from sparsify.losses import LossConfigs, calc_loss
+from sparsify.metrics import DiscreteMetrics, collect_wandb_metrics
 from sparsify.models.sparsifiers import SAE
 from sparsify.models.transformers import SAETransformer
 from sparsify.scripts.train_tlens.run_train_tlens import HookedTransformerPreConfig
 from sparsify.types import RootPath, Samples
-from sparsify.utils import load_config, save_model, set_seed
+from sparsify.utils import (
+    load_config,
+    save_model,
+    set_seed,
+)
 
 
 class TrainConfig(BaseModel):
@@ -55,6 +60,15 @@ class TrainConfig(BaseModel):
     scheduler: str | None = None
     warmup_steps: NonNegativeFloat = 0
     max_grad_norm: PositiveFloat | None = None
+    log_every_n_steps: PositiveInt = 20
+    collect_discrete_metrics_every_n_samples: PositiveInt = Field(
+        20_000,
+        description="Metrics such as activation frequency and alive neurons, are calculated over "
+        "discrete periods. This parameter specifies how often to calculate these metrics.",
+    )
+    discrete_metrics_n_tokens: PositiveInt = Field(
+        100_000, description="The number of tokens to caclulate discrete metrics over."
+    )
     loss_configs: LossConfigs
 
     @model_validator(mode="after")
@@ -112,7 +126,6 @@ def train(
     device: torch.device,
 ) -> None:
     model.saes.train()
-    # TODO make appropriate for transcoders and metaSAEs
     optimizer = torch.optim.Adam(model.saes.parameters(), lr=config.train.lr)
 
     scheduler = None
@@ -158,6 +171,8 @@ def train(
     total_samples_at_last_save = 0
     grad_updates = 0
     grad_norm: float | None = None
+    samples_since_discrete_metric_collection: int = 0
+    discrete_metrics: DiscreteMetrics | None = None
 
     for step, batch in tqdm(enumerate(data_loader), total=n_batches, desc="Steps"):
         tokens: Int[Tensor, "batch pos"] = batch[config.data.column_name].to(device=device)
@@ -206,46 +221,52 @@ def train(
                 scheduler.step()
 
         total_samples += tokens.shape[0]
-        if step == 0 or step % 20 == 0:
+        samples_since_discrete_metric_collection += tokens.shape[0]
+
+        if discrete_metrics is None and (
+            samples_since_discrete_metric_collection
+            >= config.train.collect_discrete_metrics_every_n_samples
+        ):
+            # Start collecting discrete metrics for next config.train.discrete_metrics_n_tokens
+            discrete_metrics = DiscreteMetrics(
+                dict_sizes={
+                    hook_name: sae_acts[hook_name]["c"].shape[-1] for hook_name in sae_acts
+                },
+                has_pos_dim=True,
+                device=device,
+            )
+            samples_since_discrete_metric_collection = 0
+
+        if discrete_metrics is not None:
+            discrete_metrics.update_dict_el_frequencies(
+                sae_acts, batch_tokens=tokens.shape[0] * tokens.shape[1]
+            )
+            if discrete_metrics.tokens_used >= config.train.discrete_metrics_n_tokens:
+                # Finished collecting discrete metrics
+                metrics = discrete_metrics.collect_for_logging()
+                if config.wandb_project:
+                    # TODO: Log when not using wandb too
+                    wandb.log(metrics, step=total_samples)
+                discrete_metrics = None
+                samples_since_discrete_metric_collection = 0
+
+        if step == 0 or step % config.train.log_every_n_steps == 0:
             tqdm.write(
                 f"Samples {total_samples} Step {step} GradUpdates {grad_updates} "
                 f"Loss {loss.item():.5f}"
             )
 
             if config.wandb_project:
-                wandb_log_info = {"loss": loss.item(), "grad_updates": grad_updates}
-                for loss_name, loss_value in loss_dict.items():
-                    wandb_log_info[loss_name] = loss_value.item()
-
-                if config.train.max_grad_norm is not None:
-                    assert grad_norm is not None
-                    wandb_log_info["grad_norm"] = grad_norm
-                if step == 0 or step % 5 == 0:
-                    orig_logits_logging = orig_logits.detach().clone()
-                    new_logits_logging = new_logits.detach().clone()
-                    orig_model_performance_loss = lm_cross_entropy_loss(
-                        orig_logits_logging, tokens, per_token=False
-                    )
-                    sae_model_performance_loss = lm_cross_entropy_loss(
-                        new_logits_logging, tokens, per_token=False
-                    )
-                    # flat_orig_logits = orig_logits.view(-1, orig_logits.shape[-1])
-                    # flat_new_logits = new_logits.view(-1, new_logits.shape[-1])
-                    # kl_div = torch.nn.functional.kl_div(
-                    #     torch.nn.functional.log_softmax(flat_new_logits, dim=-1),
-                    #     torch.nn.functional.softmax(flat_orig_logits, dim=-1),
-                    #     reduction="batchmean",
-                    # ) # Unsure if this is correct. Also it's expensive in terms of memory.
-
-                    wandb_log_info.update(
-                        {
-                            "performance/orig_model_ce_loss": orig_model_performance_loss.item(),
-                            "performance/sae_model_ce_loss": sae_model_performance_loss.item(),
-                            "performance/difference_loss": (
-                                orig_model_performance_loss - sae_model_performance_loss
-                            ).item(),
-                        },
-                    )
+                wandb_log_info = collect_wandb_metrics(
+                    loss=loss.item(),
+                    grad_updates=grad_updates,
+                    sae_acts=sae_acts,
+                    loss_dict=loss_dict,
+                    grad_norm=grad_norm,
+                    orig_logits=orig_logits.detach().clone(),
+                    new_logits=new_logits.detach().clone(),
+                    tokens=tokens,
+                )
                 wandb.log(wandb_log_info, step=total_samples)
         if (
             save_dir

--- a/sparsify/scripts/train_tlens_saes/tinystories_1M.yaml
+++ b/sparsify/scripts/train_tlens_saes/tinystories_1M.yaml
@@ -3,16 +3,19 @@ tlens_model_name: roneneldan/TinyStories-1M
 tlens_model_path: null
 train:
   save_every_n_samples: null
-  n_samples: 40000
-  batch_size: 16
-  effective_batch_size: 16
-  lr: 1e-3
-  warmup_steps: 0
+  n_samples: 200000  # 918604 samples of 512 tokens
+  log_every_n_steps: 20
+  collect_discrete_metrics_every_n_samples: 10000
+  discrete_metrics_n_tokens: 500_000  #500k tokens is ~977 samples
+  batch_size: 12
+  effective_batch_size: 12
+  lr: 5e-3
+  warmup_steps: 500
   max_grad_norm: 1.0
   loss_configs:
     sparsity:
       p_norm: 0.5
-      coeff: 0.001
+      coeff: 5e-6
     inp_to_orig: null
     out_to_orig: null
     inp_to_out: null
@@ -26,7 +29,7 @@ data:
   split: train
   n_ctx: 512
 saes:
-  sae_position_name: blocks.3.hook_resid_post
-  dict_size_to_input_ratio: 1.0
+  sae_position_name: hook_resid_post
+  dict_size_to_input_ratio: 10.0
 wandb_project: tinystories-1m
 


### PR DESCRIPTION
## Description
- Adds a `DiscreteMetric` class which collects the activation frequency of each dictionary element.
- The class has a `collect_for_logging` method which uses the activation frequencies to create histograms and a count of "alive_dict_elements" for logging to wandb.
- The config now has a `collect_discrete_metrics_every_n_samples` which defines when to start collecting samples for our discrete metrics.
- It also has a `discrete_metrics_n_tokens` which defines how many tokens should be included in each discrete metric log.

## How Has This Been Tested?
No tests.

## Does this PR introduce a breaking change?
No
