### PR TITLE
Allow forward passes to stop early for efficiency

### DIFF
--- a/sparsify/scripts/train_tlens_saes/run_train_tlens_saes.py
+++ b/sparsify/scripts/train_tlens_saes/run_train_tlens_saes.py
@@ -160,7 +160,9 @@ def train(
 
     # We don't need to run through the whole model if we're not using the logits
     stop_at_layer = None
-    if config.train.loss_configs.logits_kl is None and all(name.startswith("blocks.") for name in model.raw_sae_position_names):
+    if config.train.loss_configs.logits_kl is None and all(
+        name.startswith("blocks.") for name in model.raw_sae_position_names
+    ):
         stop_at_layer = (
             max(
                 [


### PR DESCRIPTION
If `config.train.loss_configs.logits_kl` is `None`,  then we don't need to run a forward pass through the whole model, because all we need are the activations at some intermediate layers, not the final logits. This commit only runs the forward pass up to the last required layer (in `model.raw_sae_position_names`).

See comparsions between runs with and without "_stop_at_layer" for validation that you get the same results much more efficiently here: https://wandb.ai/sparsify/tinystories-1m_layerwise_play

### Validation
I've validated by running `tinystories_1M_layerwise` with `logits_kl: null`, and checking that I get exactly the same loss curves with and without early layer stopping. 
I have not validated for non-layerwise training or with `logits_kl` set. 
https://wandb.ai/sparsify/tinystories-1m_layerwise_play/reports/loss-24-02-16-15-49-07---Vmlldzo2ODQ0NTMy
![image](https://github.com/ApolloResearch/sparsify/assets/52150832/4fcc6701-1418-408b-b976-91884ddd7394)

### Performance
For early layers, less than half the GPU memory as before gets allocated, and training finishes in less than half of the time: 
https://wandb.ai/sparsify/tinystories-1m_layerwise_play/reports/Process-GPU-Memory-Allocated-24-02-16-15-48-54---Vmlldzo2ODQ0NTI5
![image](https://github.com/ApolloResearch/sparsify/assets/52150832/6601dda6-92fd-406d-b101-9ea7c0c45634)

