### PR TITLE
Generate over-time feature density histograms

### DIFF
--- a/sparsify/metrics.py
+++ b/sparsify/metrics.py
@@ -1,7 +1,7 @@
 import torch
 import wandb
 from jaxtyping import Float
-from torch import Tensor, log10
+from torch import Tensor
 from transformer_lens.utils import lm_cross_entropy_loss
 
 
@@ -83,7 +83,7 @@ class DiscreteMetrics:
                 log_dict[
                     f"sparsity/dict_el_frequencies_hist/over_time/log10/{sae_pos}"
                 ] = wandb.Histogram(
-                    [log10(s + 1e-10) for s in self.dict_el_frequencies_history[sae_pos]]
+                    [torch.log10(s + 1e-10) for s in self.dict_el_frequencies_history[sae_pos]]
                 )
         return log_dict
 

--- a/sparsify/scripts/train_tlens_saes/run_train_tlens_saes.py
+++ b/sparsify/scripts/train_tlens_saes/run_train_tlens_saes.py
@@ -181,17 +181,11 @@ def train(
         )
 
     # Initialize wandb
-    if config.wandb_run_name is not None:
-        run_name = (
-            config.wandb_run_name_prefix + config.wandb_run_name + config.wandb_run_name_suffix
-        )
-    else:
-        run_name = (
-            config.wandb_run_name_prefix
-            + f"{'-'.join(config.saes.sae_position_names)}_ratio-{config.saes.dict_size_to_input_ratio}_"
-            f"lr-{config.train.lr}_lpcoeff-{config.train.loss_configs.sparsity.coeff}"
-            + config.wandb_run_name_suffix
-        )
+    run_name = config.wandb_run_name or (
+        f"{'-'.join(config.saes.sae_position_names)}_ratio-{config.saes.dict_size_to_input_ratio}_"
+        f"lr-{config.train.lr}_lpcoeff-{config.train.loss_configs.sparsity.coeff}"
+    )
+    run_name = config.wandb_run_name_prefix + run_name + config.wandb_run_name_suffix
     if config.wandb_project:
         load_dotenv(override=True)
         wandb.init(
@@ -326,8 +320,6 @@ def train(
                     new_logits=new_logits.detach().clone() if new_logits is not None else None,
                     tokens=tokens,
                 )
-                if scheduler is not None:
-                    wandb_log_info["lr"] = scheduler.get_last_lr()[0]
                 wandb.log(wandb_log_info, step=total_samples)
         if (
             save_dir


### PR DESCRIPTION
Add dict_el_frequencies_hist/over_time plots to wandb.

Here's an example of them from [one of Joseph's runs](https://wandb.ai/jbloom/mats_sae_training_gpt2_small_resid_pre_5/runs/99155rv4?workspace=user-jordantensor):
![image](https://github.com/ApolloResearch/sparsify/assets/52150832/f975b120-f2ed-48e2-b541-18eb132f7dba)

And here's what it now looks like in our wandb when an SAE is failing badly at getting any sparsely activating features: 
![image](https://github.com/ApolloResearch/sparsify/assets/52150832/8e6feaf1-d6ee-4f06-afe0-fb6740f188f4)

[edit] And here's an example of it working well on [a layerwise run where I tried to mimic Joseph's parameters](https://wandb.ai/sparsify/gpt2-small_compare-with-joseph_layerwise/runs/sz3ccd9d/workspace):
![image](https://github.com/ApolloResearch/sparsify/assets/52150832/f44aed14-95f6-46fa-8e79-ee36d4ac76f0)
