### PR TITLE
WIP: Interpolate between sae and orig acts

### DIFF
--- a/sparsify/metrics.py
+++ b/sparsify/metrics.py
@@ -83,6 +83,7 @@ def collect_wandb_metrics(
     orig_logits: Float[Tensor, "... dim"] | None,
     new_logits: Float[Tensor, "... dim"] | None,
     tokens: Float[Tensor, "... dim"],
+    percent_sae_acts: float,
 ) -> dict[str, int | float]:
     """Collect metrics for logging to wandb.
 
@@ -95,11 +96,17 @@ def collect_wandb_metrics(
         orig_logits: The logits produced by the original model.
         new_logits: The logits produced by the SAE model.
         tokens: The tokens used to produce the logits and activations.
+        percent_sae_acts: The percentage of SAE activations vs original model activations used to
+            patch the activations at each SAE.
 
     Returns:
         Dictionary of metrics to log to wandb.
     """
-    wandb_log_info = {"loss": loss, "grad_updates": grad_updates}
+    wandb_log_info = {
+        "loss": loss,
+        "grad_updates": grad_updates,
+        "percent_sae_acts": percent_sae_acts,
+    }
     for name, sae_act in sae_acts.items():
         # Record L_0 norm of the cs
         l_0_norm = torch.norm(sae_act["c"], p=0, dim=-1).mean().item()

--- a/sparsify/scripts/train_tlens_saes/tinystories_1M.yaml
+++ b/sparsify/scripts/train_tlens_saes/tinystories_1M.yaml
@@ -8,11 +8,12 @@ train:
   collect_discrete_metrics_every_n_samples: 10000
   discrete_metrics_n_tokens: 500_000  #500k tokens is ~977 samples
   log_ce_loss: true
-  batch_size: 12
-  effective_batch_size: 12
+  batch_size: 10
+  effective_batch_size: 10
   lr: 5e-3
   warmup_steps: 500
   max_grad_norm: 1.0
+  interpolate_n_steps: 500
   loss_configs:
     sparsity:
       p_norm: 0.6
@@ -32,5 +33,5 @@ data:
 saes:
   sae_position_names: hook_resid_post
   dict_size_to_input_ratio: 10.0
-wandb_project: tinystories-1m
+wandb_project: tinystories-1m-interpolate-play
 

--- a/sparsify/utils.py
+++ b/sparsify/utils.py
@@ -1,4 +1,5 @@
 import random
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, TypeVar
 
@@ -129,3 +130,28 @@ def filter_names(all_names: list[str], filter_names: list[str]) -> list[str]:
         The filtered names.
     """
     return [name for name in all_names if any(filter_name in name for filter_name in filter_names)]
+
+
+def get_interpolation_schedule(
+    n_steps: int, start_sae_percent: float = 0.0, end_sae_percent: float = 1.0
+) -> Callable[[int], float]:
+    """Create a function which takes in a step and returns the percentage of sae activations vs
+    original model activations to use at that step.
+
+    If n_steps is 0, the function will always return end_sae_percent.
+
+    Args:
+        n_steps: The number of steps in the interpolation.
+        start_sae_percent: Percentage of sae activations to use at step 0.
+        end_sae_percent: Percentage of sae activations to use at the final step.
+
+    Returns:
+        Function which takes in a step and returns the percentage of sae activations to use.
+    """
+
+    def _interpolation_schedule(step: int) -> float:
+        if step >= n_steps:
+            return end_sae_percent
+        return start_sae_percent + (end_sae_percent - start_sae_percent) * step / n_steps
+
+    return _interpolation_schedule


### PR DESCRIPTION
NOTE: This interpolation does not yet provide any benefit, as can be seen by [these](https://wandb.ai/sparsify/tinystories-1m-interpolate-play/) wandb runs. We won't merge to main unless we work how to get it to improve on the default training method.

## Description
- Make the output of each SAE linearly interpolate between the sae output and the original model activations
- Adds an `interpolate_n_steps` param to the config, which defines the number of steps that the linear schedule should run for.
    - A value of 0 means that we should always use the sae acts.
    - A value of "all" means that the schedule runs over the whole training set
    - A different value will specify how many steps of linear interpolation before we start using the sae acts only.

## Motivation and Context
See thread [here](https://apolloresearchhq.slack.com/archives/C06G8H12Z6H/p1708377232516019?thread_ts=1708365121.637219&cid=C06G8H12Z6H)

## How Has This Been Tested?
No tests.

## Does this PR introduce a breaking change?
No.
