### PR TITLE
Add lr schedule with cooldown

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,57 @@
+import pytest
+
+from sparsify.utils import get_linear_lr_schedule
+
+
+class TestLinearLRSchedule:
+    @pytest.mark.parametrize(
+        "warmup_samples, cooldown_samples, n_samples, effective_batch_size, expected_error",
+        [
+            (100, 50, None, 10, AssertionError),  # Cooldown requested without setting n_samples
+            (100, 100, 150, 10, AssertionError),  # Cooldown starts before warmup ends
+        ],
+    )
+    def test_value_errors(
+        self,
+        warmup_samples: int,
+        cooldown_samples: int,
+        n_samples: int | None,
+        effective_batch_size: int,
+        expected_error: type[BaseException],
+    ):
+        with pytest.raises(expected_error):
+            get_linear_lr_schedule(
+                warmup_samples, cooldown_samples, n_samples, effective_batch_size
+            )
+
+    def test_constant_lr(self):
+        lr_schedule = get_linear_lr_schedule(
+            warmup_samples=0, cooldown_samples=0, n_samples=None, effective_batch_size=10
+        )
+        for step in range(0, 100):
+            assert lr_schedule(step) == 1.0, "Learning rate should be constant at 1.0"
+
+    @pytest.mark.parametrize(
+        "warmup_samples, cooldown_samples, n_samples, effective_batch_size, step, expected_lr",
+        [
+            (100, 0, None, 10, 5, 0.6),  # During warmup
+            (100, 200, 1000, 10, 50, 1.0),  # After warmup, before cooldown
+            (100, 100, 1000, 10, 91, 0.9),  # During cooldown
+            (100, 100, 1000, 10, 100, 0.0),  # After cooldown
+        ],
+    )
+    def test_learning_rate_transitions(
+        self,
+        warmup_samples: int,
+        cooldown_samples: int,
+        n_samples: int,
+        effective_batch_size: int,
+        step: int,
+        expected_lr: float,
+    ):
+        lr_schedule = get_linear_lr_schedule(
+            warmup_samples, cooldown_samples, n_samples, effective_batch_size
+        )
+        assert lr_schedule(step) == pytest.approx(
+            expected_lr
+        ), f"Learning rate at step {step} should be {expected_lr}"


### PR DESCRIPTION
## Description
- Adds a `get_linear_lr_schedule` function to sparsify.utils which creates a linear schedule with warmup and cooldown

## Motivation and Context
We're still struggling to converge to ~0 loss, especially with the new dataset. Reducing the LR towards the end of training may help with this. Also, [others](https://transformer-circuits.pub/2024/feb-update/index.html) have reported that a cooldown is useful for minimising dead features.

## How Has This Been Tested?
- Added `tests.test_utils.TestLinearLRSchedule` which tests various combinations of schedule configs.
- [This](https://wandb.ai/sparsify/tinystories-1m/runs/c3zvo7zv?workspace=user-danbraunai-apollo) wandb run shows the warmup and cooldown rate taking effect in a run.

## Does this PR introduce a breaking change?
No
