### PR TITLE
Add joseph's normalized mse loss to experiment/joseph-replication

### DIFF
--- a/sparsify/scripts/train_tlens_saes/gpt2-pile10k.yaml
+++ b/sparsify/scripts/train_tlens_saes/gpt2-pile10k.yaml
@@ -19,6 +19,7 @@ train:
     inp_to_out: null
     logits_kl:
       coeff: 1.0
+    normalize_mse: True
 data:
   dataset_name: NeelNanda/pile-10k
   is_tokenized: false

--- a/sparsify/scripts/train_tlens_saes/gpt2.yaml
+++ b/sparsify/scripts/train_tlens_saes/gpt2.yaml
@@ -19,6 +19,7 @@ train:
     inp_to_out: null
     logits_kl:
       coeff: 1.0
+    normalize_mse: True
 data:
   dataset_name: apollo-research/sae-Skylion007-openwebtext-tokenizer-gpt2
   is_tokenized: true

--- a/sparsify/scripts/train_tlens_saes/pythia_14m.yaml
+++ b/sparsify/scripts/train_tlens_saes/pythia_14m.yaml
@@ -18,6 +18,7 @@ train:
       coeff: 1.0
     inp_to_out: null
     logits_kl: null
+    normalize_mse: True
 data:
   dataset_name: apollo-research/sae-monology-pile-uncopyrighted-tokenizer-EleutherAI-gpt-neox-20b
   is_tokenized: true

--- a/sparsify/scripts/train_tlens_saes/tiny_gpt2.yaml
+++ b/sparsify/scripts/train_tlens_saes/tiny_gpt2.yaml
@@ -15,6 +15,7 @@ train:
     inp_to_out: null
     logits_kl:
       coeff: 1.0
+    normalize_mse: True
 data:
   dataset_name: apollo-research/sae-Skylion007-openwebtext-tokenizer-gpt2
   is_tokenized: true

--- a/sparsify/scripts/train_tlens_saes/tinystories_1M.yaml
+++ b/sparsify/scripts/train_tlens_saes/tinystories_1M.yaml
@@ -22,6 +22,7 @@ train:
     inp_to_out: null
     logits_kl:
       coeff: 1.0
+    normalize_mse: True
 data:
   dataset_name: apollo-research/sae-skeskinen-TinyStories-hf-tokenizer-gpt2
   is_tokenized: true

--- a/sparsify/scripts/train_tlens_saes/tinystories_1M_layerwise.yaml
+++ b/sparsify/scripts/train_tlens_saes/tinystories_1M_layerwise.yaml
@@ -22,6 +22,7 @@ train:
     inp_to_out:
       coeff: 1.0
     logits_kl: null
+    normalize_mse: True
 data:
   dataset_name: apollo-research/sae-Skylion007-openwebtext-tokenizer-gpt2
   is_tokenized: true


### PR DESCRIPTION
Adds a normalize option to the mse_loss (defaults to true):
```python
def mse_loss(x: Float[Tensor, "... dim"], orig: Float[Tensor, "... dim"], normalize: bool = True):
    if normalize:
        x_centred = x - x.mean(dim=0, keepdim=True)
        norm = (x_centred**2).sum(dim=-1, keepdim=True).sqrt()
    else:
        norm = 1.0
    return (torch.pow((orig - x.float()), 2) / norm).mean()
```
This replicates Joseph's mse loss: [mats_sae_training/sae_training/sparse_autoencoder.py line 100](https://github.com/jbloomAus/mats_sae_training/blob/f3fe937303f0eb54e83771d1b307c3f09d1145fd/sae_training/sparse_autoencoder.py#L100)

## How Has This Been Tested?
Tested in this run: https://wandb.ai/sparsify/gpt2-small_compare-with-joseph_layerwise_2024_02_27/runs/94dfhgdv?workspace=user-jordantensor

## Does this PR introduce a breaking change?
Yes - the default mse loss is now Joseph's. Let me know if the default should be ours