### PR TITLE
Collect output metrics for layerwise runs

### DIFF
--- a/sparsify/scripts/train_tlens_saes/tinystories_1M.yaml
+++ b/sparsify/scripts/train_tlens_saes/tinystories_1M.yaml
@@ -4,7 +4,7 @@ tlens_model_path: null
 train:
   save_every_n_samples: null
   n_samples: 100000  # 918604 samples of 512 tokens
-  log_every_n_batches: 20
+  log_every_n_grad_steps: 20
   collect_discrete_metrics_every_n_samples: 10000
   discrete_metrics_n_tokens: 500_000  #500k tokens is ~977 samples
   batch_size: 10

--- a/sparsify/scripts/train_tlens_saes/tinystories_1M_layerwise.yaml
+++ b/sparsify/scripts/train_tlens_saes/tinystories_1M_layerwise.yaml
@@ -4,7 +4,7 @@ tlens_model_path: null
 train:
   save_every_n_samples: null
   n_samples: 300000  # 918604 samples of 512 tokens
-  log_every_n_batches: 20
+  log_every_n_grad_steps: 20
   collect_discrete_metrics_every_n_samples: 10000
   discrete_metrics_n_tokens: 500_000  #500k tokens is ~977 samples
   collect_output_metrics_every_n_samples: 10000


### PR DESCRIPTION
## Description
- Replaced `log_ce_loss` with `collect_output_metric_every_n_samples` config option for occasionally running the entire model and collecting metrics such as CE loss and topk
- Change `log_every_n_steps` -> `log_every_n_grad_steps` (a "step" typically refers to a gradient step but we make it clear), as well as changing the logic to actual update based on gradient steps rather than batches
- Adds a layerwise config.


## Motivation and Context
For layerwise runs, we previously had two options:
1. Never collect output metrics. This is sad because we want to see our CE loss diff and kl divergence.
2. Collect output metrics at every batch. This was very slow.

## How Has This Been Tested?
No tests. Here's a run which collects output metrics every 10k samples https://wandb.ai/sparsify/tinystories-1m_play/runs/kwtn4ccb.

## Does this PR introduce a breaking change?
- `log_every_n_steps` -> `log_every_n_grad_steps`.
- `log_ce_loss` is no longer a valid config option.
