### PR TITLE
Avoid altering decoder data attribute for norm

### DIFF
--- a/sparsify/models/sparsifiers.py
+++ b/sparsify/models/sparsifiers.py
@@ -3,6 +3,7 @@ Defines a generic MLP.
 """
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 
@@ -23,13 +24,15 @@ class SAE(nn.Module):
         self.decoder.weight.data = nn.init.orthogonal_(self.decoder.weight.data.T).T
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Pass input through the encoder and normalized decoder."""
         c = self.encoder(x)
-
-        # Apply unit norm constraint so that each dictionary component has unit norm
-        self.decoder.weight.data = nn.functional.normalize(self.decoder.weight.data, dim=0)
-
-        x_hat = self.decoder(c)
+        x_hat = F.linear(c, self.dict_elements, bias=self.decoder.bias)
         return x_hat, c
+
+    @property
+    def dict_elements(self):
+        """Dictionary elements are simply the normalized decoder weights."""
+        return F.normalize(self.decoder.weight, dim=0)
 
     @property
     def device(self):
@@ -57,10 +60,8 @@ class Codebook(nn.Module):
         self.k = k
 
     def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
-        # Compute cosine similarity between input and codebook features
-        cos_sim = nn.functional.cosine_similarity(
-            x.unsqueeze(1), self.codebook, dim=2
-        )  # (batch_size, n_dict_components)
+        # Compute cosine similarity between input and codebook features (batch_size, dict_size)
+        cos_sim = F.cosine_similarity(x.unsqueeze(1), self.codebook, dim=2)
 
         # Take the top k most similar codebook features
         _, topk = torch.topk(cos_sim, self.k, dim=1)  # (batch_size, k)


### PR DESCRIPTION
## Description
Normalize decoder weights with new variable rather than altering data attribute. This has the effect of syncing up the Adam gradient information with the actual gradients, as well as avoiding potential issues that can arise with altering data attributes of parameters after other operations have been done on them (in prior forward passes).

## Related Issue
Closes #44

## How Has This Been Tested?
Checked memory consumption of new method with old method on large dict training. Both are identical.

## Does this PR introduce a breaking change?
No
