### PR TITLE
Remove dividing loss by n_grad_accumulation_steps

### DIFF
--- a/e2e_sae/scripts/train_tlens/run_train_tlens.py
+++ b/e2e_sae/scripts/train_tlens/run_train_tlens.py
@@ -112,7 +112,6 @@ def train(config: Config, model: HookedTransformer, device: torch.device) -> Non
             tokens: Int[Tensor, "batch pos"] = batch["tokens"].to(device=device)
             loss = model(tokens, return_type="loss")
 
-            loss = loss / n_gradient_accumulation_steps
             loss.backward()
 
             if (step + 1) % n_gradient_accumulation_steps == 0:

--- a/e2e_sae/scripts/train_tlens_saes/run_train_tlens_saes.py
+++ b/e2e_sae/scripts/train_tlens_saes/run_train_tlens_saes.py
@@ -435,7 +435,6 @@ def train(
             is_log_step=is_log_step,
         )
 
-        loss = loss / n_gradient_accumulation_steps
         loss.backward()
 
         if is_grad_step:


### PR DESCRIPTION
## Description
- Removes the lines `loss = loss / n_gradient_accumulation_steps` in training tlens models and saes

## Related Issue
Fixes #59 

## Motivation and Context
It makes more sense not to divide the loss by the number of gradient accumulation steps. Fixing this would make the results robust to the `effect_batch_size` and independent of `batch_size`.

## How Has This Been Tested?
Ran two runs with and without the division. The results on alive_dict_elements, L0 and CE loss difference are VERY close. Run with division (i.e. before the change) [here](https://wandb.ai/sparsify/gpt2-layerwise-2/runs/ej4s0u1u). Run without division (i.e. after the change) [here](https://wandb.ai/sparsify/gpt2-layerwise-2/runs/bo6whj93).

## Does this PR introduce a breaking change?
Yes. Runs after this change will have train slightly differetnly (in particular, they will have a different grad norm throughout training). Though final results are very similar (see above).
