### PR TITLE
Divide loss by grad accumulation steps

### DIFF
--- a/e2e_sae/scripts/train_tlens/run_train_tlens.py
+++ b/e2e_sae/scripts/train_tlens/run_train_tlens.py
@@ -112,6 +112,7 @@ def train(config: Config, model: HookedTransformer, device: torch.device) -> Non
             tokens: Int[Tensor, "batch pos"] = batch["tokens"].to(device=device)
             loss = model(tokens, return_type="loss")
 
+            loss = loss / n_gradient_accumulation_steps
             loss.backward()
 
             if (step + 1) % n_gradient_accumulation_steps == 0:

--- a/e2e_sae/scripts/train_tlens_saes/run_train_tlens_saes.py
+++ b/e2e_sae/scripts/train_tlens_saes/run_train_tlens_saes.py
@@ -435,6 +435,7 @@ def train(
             is_log_step=is_log_step,
         )
 
+        loss = loss / n_gradient_accumulation_steps
         loss.backward()
 
         if is_grad_step:


### PR DESCRIPTION
## Description
Divides the loss at each step by the number of gradient accumulation steps

Reverts the change made in #68 which incorrectly removed this. We need to do this division because our losses include means.

## Does this PR introduce a breaking change?
Yes. Losses will no longer be equal when holding all hyperparams fixed.
