### PR TITLE
Fix autointerp pyright issues

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup node
       uses: actions/setup-node@v4
       with:
-        node-version: 20
+        node-version: 21
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/e2e_sae/scripts/analysis/activation_analysis.py
+++ b/e2e_sae/scripts/analysis/activation_analysis.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import cast
 
 import torch
 import torch.nn.functional as F
@@ -144,8 +143,8 @@ def get_acts(
 
 def norm_scatterplot(
     acts: Acts,
-    xlim: tuple[int | None, int | None] = (0, None),
-    ylim: tuple[int | None, int | None] = (0, None),
+    xlim: tuple[float | None, float | None] = (0, None),
+    ylim: tuple[float | None, float | None] = (0, None),
     inset_extent: int = 150,
     out_file: Path | None = None,
     inset_pos: tuple[float, float, float, float] = (0.2, 0.2, 0.6, 0.7),
@@ -157,10 +156,10 @@ def norm_scatterplot(
     recon_norms = torch.norm(acts.recon.flatten(0, 1), dim=-1)
 
     plt.subplots(figsize=figsize)
-    ax = cast(plt.Axes, plt.gca())
+    ax = plt.gca()
     ax.scatter(orig_norm, recon_norms, alpha=scatter_alphas[0], s=3, c="k")
-    ax.set_xlim(xlim)
-    ax.set_ylim(ylim)
+    ax.set_xlim(xlim)  # type: ignore
+    ax.set_ylim(ylim)  # type: ignore
     ax.set_aspect("equal")
     if xlim[1] is not None:
         ax.set_xticks(range(0, xlim[1] + 1, 1000))  # type: ignore[reportCallIssue]
@@ -178,6 +177,7 @@ def norm_scatterplot(
     axins.plot([0, inset_extent], [0, inset_extent], "k--", alpha=1, lw=0.8)
     axins.set_aspect("equal")
     if main_plot_diag_line:
+        assert xlim[1] is not None
         ax.plot([0, xlim[1]], [0, xlim[1]], "k--", alpha=0.5, lw=0.8)
 
     ax.indicate_inset_zoom(axins, edgecolor="black")

--- a/e2e_sae/scripts/analysis/autointerp.py
+++ b/e2e_sae/scripts/analysis/autointerp.py
@@ -42,6 +42,9 @@ from scipy.stats import bootstrap
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 from tqdm import tqdm
 
+# Disable the following pyright checks due to issues with neuron_explainer's FastDataclass
+# pyright: reportCallIssue=false, reportAttributeAccessIssue=false
+
 load_dotenv()  # Required before importing UncalibratedNeuronSimulator
 NEURONPEDIA_DOMAIN = "https://neuronpedia.org"
 POSITIVE_INF_REPLACEMENT = 9999

--- a/e2e_sae/scripts/analysis/geometric_analysis.py
+++ b/e2e_sae/scripts/analysis/geometric_analysis.py
@@ -868,7 +868,7 @@ def create_subplot_hists(
     """
     fig = fig or plt.figure(figsize=figsize, layout="constrained")
     axs = fig.subplots(len(sim_list), 1, sharex=True, gridspec_kw={"hspace": 0.1})
-    axs = np.atleast_1d(axs)
+    axs = np.atleast_1d(axs)  # type: ignore
     colors = colors or [None for _ in sim_list]
     for ax, sims, title, color in zip(axs, sim_list, titles, colors, strict=True):
         ax.hist(sims.flatten().detach().numpy(), range=xlim, bins=bins, color=color, alpha=alpha)
@@ -908,7 +908,7 @@ def create_subplot_hists_short(
     fig = fig or plt.figure(figsize=figsize)
     axs = fig.subplots(len(sim_list), 1, sharex=True)
     plt.subplots_adjust(left=left_pad, top=0.95, bottom=(0.5 / figsize[1]), hspace=0.2, right=0.95)
-    axs = np.atleast_1d(axs)
+    axs = np.atleast_1d(axs)  # type: ignore
     colors = colors or [None for _ in sim_list]
     for ax, sims, title, color in zip(axs, sim_list, titles, colors, strict=True):
         ax.hist(sims.flatten().detach().numpy(), bins=bins, color=color, alpha=alpha, density=True)


### PR DESCRIPTION
## Description
- Ignore some pyright errors in `e2e_sae/scripts/analysis/autointerp.py` due to typing issues in neuron_explainer

## Motivation and Context
Since we unpinned versions, a number of pyright issues appeared.

## Does this PR introduce a breaking change?
No
